### PR TITLE
Example of bug in refreshing tokens

### DIFF
--- a/custom-sign-in/app/ProfileScreen.js
+++ b/custom-sign-in/app/ProfileScreen.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
@@ -24,9 +24,11 @@ import {
   authenticate,
   getAccessToken,
   EventEmitter,
+  refreshTokens
 } from '@okta/okta-react-native';
 import Spinner from 'react-native-loading-spinner-overlay';
 import configFile from './../samples.config';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 export default class ProfileScreen extends React.Component {
   static navigationOptions = {
@@ -84,6 +86,17 @@ export default class ProfileScreen extends React.Component {
     authenticate({sessionToken});
   }
 
+  async refreshTokens() {
+    try {
+      const newTokens = await refreshTokens();
+      console.log('newTokens', newTokens);
+    } catch (error) {
+      console.warn('failed to refresh', error)
+      console.warn('error string-ified', JSON.stringify(error))
+    }
+    
+  }
+
   render() {
     const {navigation} = this.props;
     const transaction = navigation.getParam('transaction', 'NO-ID');
@@ -94,6 +107,10 @@ export default class ProfileScreen extends React.Component {
         <View style={{marginTop: 60, height: 140}}>
           <Text>Access Token:</Text>
           <Text style={{marginTop: 20}}>{this.state.accessToken}</Text>
+          <TouchableOpacity onPress={async () => this.refreshTokens()}>
+            <Text style={{ color: 'blue', marginTop: 100 }}>Refresh Tokens</Text>
+          </TouchableOpacity>
+
         </View>
       );
     } else {


### PR DESCRIPTION
I have added a button to `ProfileScreen` that attempts to refresh tokens using a custom sign in (screenshot below).

My `refreshTokens` method is quite simple:

```js
async refreshTokens() {
  try {
    const newTokens = await refreshTokens();
    console.log('newTokens', newTokens);
  } catch (error) {
    console.warn('failed to refresh', error)
    console.warn('error string-ified', JSON.stringify(error))
  }
}
```

It's in a try-catch because it fails.

When I click the `Refresh Tokens` button, here is the output in the console.

**It looks like there is a `403` response code.**

```
failed to refresh Error: Error fetching fresh tokens: Non-200 HTTP response (403) making token request to 'https://<censored>.okta.com/oauth2/default/v1/token'.
    at createErrorFromErrorData (NativeModules.js:152)
    at NativeModules.js:104
    at MessageQueue.__invokeCallback (MessageQueue.js:442)
    at MessageQueue.js:127
    at MessageQueue.__guard (MessageQueue.js:343)
    at MessageQueue.invokeCallbackAndReturnFlushedQueue (MessageQueue.js:126)
    at RNDebuggerWorker.js:2
```

```
{
  "framesToPop": 1,
  "code": "-600",
  "nativeStackIOS": [
    "0   CustomSignIn                        0x000000010e384867 RCTJSErrorFromCodeMessageAndNSError + 135",
    "1   CustomSignIn                        0x000000010e314713 __41-[RCTModuleMethod processMethodSignature]_block_invoke_2.129 + 179",
    "2   CustomSignIn                        0x000000010e24ff9b $sSo8NSStringCSgACSo7NSErrorCSgIeyByyy_SSSgAGs5Error_pSgIegggg_TR + 411",
    "3   CustomSignIn                        0x000000010e252e3f $s24OktaSdkBridgeReactNative0abC0C13refreshTokens15promiseResolver0H8RejecteryyypSgc_ySSSg_AHs5Error_pSgtctFy0A4Oidc0aL12StateManagerCSg_AJtcfU_ + 719",
    "4   CustomSignIn                        0x000000010e2455bd $s8OktaOidc0aB12StateManagerC5renew8callbackyyACSg_s5Error_pSgtc_tFySSSg_AiHtcfU_ + 861",
    "5   CustomSignIn                        0x000000010e2456d5 $s8OktaOidc0aB12StateManagerC5renew8callbackyyACSg_s5Error_pSgtc_tFySSSg_AiHtcfU_TA + 37",
    "6   CustomSignIn                        0x000000010e2458ad $sSSSgAAs5Error_pSgIegggg_So8NSStringCSgAFSo7NSErrorCSgIeyByyy_TR + 461",
    "7   CustomSignIn                        0x000000010e20d2cb __87-[OIDAuthState performActionWithFreshTokens:additionalRefreshParameters:dispatchQueue:]_block_invoke_3 + 171",
    "8   libdispatch.dylib                   0x00007fff511fb888 _dispatch_call_block_and_release + 12",
    "9   libdispatch.dylib                   0x00007fff511fc7f9 _dispatch_client_callout + 8",
    "10  libdispatch.dylib                   0x00007fff51208d22 _dispatch_main_queue_callback_4CF + 1212",
    "11  CoreFoundation                      0x00007fff23afb699 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9",
    "12  CoreFoundation                      0x00007fff23af62f9 __CFRunLoopRun + 2329",
    "13  CoreFoundation                      0x00007fff23af56b6 CFRunLoopRunSpecific + 438",
    "14  GraphicsServices                    0x00007fff3815cbb0 GSEventRunModal + 65",
    "15  UIKitCore                           0x00007fff47162a67 UIApplicationMain + 1621",
    "16  CustomSignIn                        0x000000010e194a60 main + 112",
    "17  libdyld.dylib                       0x00007fff5123bcf5 start + 1",
    "18  ???                                 0x0000000000000001 0x0 + 1"
  ],
  "domain": "OktaOidc.OktaOidcError",
  "userInfo": {}
}
```

![image](https://user-images.githubusercontent.com/54179814/66241131-57aa3480-e6cc-11e9-8b8e-4ac29a5f168b.png)
